### PR TITLE
A few updates to URR branch

### DIFF
--- a/include/openmc/urr.h
+++ b/include/openmc/urr.h
@@ -37,11 +37,11 @@ public:
 //==============================================================================
 
 struct URRXS {
-  double elastic;
-  double capture;
-  double fission;
-  double competitive;
-  double total;
+  double elastic {0.0};
+  double capture {0.0};
+  double fission {0.0};
+  double competitive {0.0};
+  double total {0.0};
 };
 
 //==============================================================================
@@ -65,8 +65,8 @@ public:
   };
 
   // Methods
-  void evaluate(double E, double sqrtkT, double target_spin, double awr,
-    Function1D& channel_radius, Function1D& scattering_radius, URRXS& xs) const;
+  URRXS evaluate(double E, double sqrtkT, double target_spin, double awr,
+    const Function1D& channel_radius, const Function1D& scattering_radius) const;
 
   // Data members
   std::vector<Resonance> res_; //!< Sampled resonance parameters

--- a/include/openmc/urr.h
+++ b/include/openmc/urr.h
@@ -88,7 +88,7 @@ public:
     double E;       //!< Energy
     double avg_d;   //!< Average level spacing
     double df_x;    //!< Degrees of freedom in competetive width distribution
-    double df_n;    //!< Degrees of freedom in neutron width distribution 
+    double df_n;    //!< Degrees of freedom in neutron width distribution
     double df_f;    //!< Degrees of freedom in fission width distribution
     double avg_gx;  //!< Average competitive reaction width
     double avg_gn0; //!< Average reduced neutron width
@@ -106,9 +106,8 @@ public:
   Unresolved(hid_t group);
 
   // Methods
-  void sample_full_ladder(ResonanceLadder* ladder, uint64_t* seed) const;
-  void sample_ladder(double energy, ResonanceLadder* ladder, uint64_t* seed)
-    const;
+  ResonanceLadder sample_full_ladder(uint64_t* seed) const;
+  ResonanceLadder sample_ladder(double energy, uint64_t* seed) const;
 
   // Data members
   Case case_; //!< Which of 3 cases

--- a/openmc/data/neutron.py
+++ b/openmc/data/neutron.py
@@ -710,14 +710,6 @@ class IncidentNeutron(EqualityMixin):
         if urr is not None:
             data.urr[strT] = urr
 
-        # Read unresolved resonance parameters
-        filename = os.path.join(os.path.dirname(__file__), 'urr.h5')
-        with h5py.File(filename, 'r') as f:
-            if name in f:
-                group = f[name]
-                rr = res.Unresolved.from_hdf5(group)
-                data.resonances = res.Resonances([rr])
-
         return data
 
     @classmethod
@@ -919,6 +911,10 @@ class IncidentNeutron(EqualityMixin):
                 heating_local.xs[temp] = Tabulated1D(E, kerma_local)
 
             data.reactions[901] = heating_local
+
+        # Add resonance data for URR
+        ev = evaluation if evaluation is not None else Evaluation(filename)
+        data.resonances = res.Resonances.from_endf(ev)
 
         return data
 

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -904,9 +904,8 @@ void Nuclide::sample_urr_xs(int n, Particle& p)
 
   for (int i = 0; i < n; ++i) {
     // Stochastically generate a resonance ladder
-    ResonanceLadder lad;
-    unr_data_->sample_ladder(p.E_, &lad, p.current_seed());
- 
+    auto lad = unr_data_->sample_ladder(p.E_, p.current_seed());
+
     // Compute cross sections
     URRXS xs;
     lad.evaluate(p.E_, p.sqrtkT_, unr_data_->target_spin_, unr_data_->awr_,

--- a/src/nuclide.cpp
+++ b/src/nuclide.cpp
@@ -907,9 +907,8 @@ void Nuclide::sample_urr_xs(int n, Particle& p)
     auto lad = unr_data_->sample_ladder(p.E_, p.current_seed());
 
     // Compute cross sections
-    URRXS xs;
-    lad.evaluate(p.E_, p.sqrtkT_, unr_data_->target_spin_, unr_data_->awr_,
-      *unr_data_->channel_radius_, *unr_data_->scattering_radius_, xs);
+    auto xs = lad.evaluate(p.E_, p.sqrtkT_, unr_data_->target_spin_, unr_data_->awr_,
+      *unr_data_->channel_radius_, *unr_data_->scattering_radius_);
 
     // Check for negative elastic cross sections
     auto& micro = p.neutron_xs_[i_nuclide_];

--- a/src/urr.cpp
+++ b/src/urr.cpp
@@ -313,15 +313,12 @@ ResonanceLadder Unresolved::sample_ladder(double energy, uint64_t* seed) const
 // ResonanceLadder implementation
 //==============================================================================
 
-void ResonanceLadder::evaluate(double E, double sqrtkT, double target_spin, double
-  awr, Function1D& channel_radius, Function1D& scattering_radius, URRXS& xs) const
+URRXS ResonanceLadder::evaluate(double E, double sqrtkT, double target_spin, double
+  awr, const Function1D& channel_radius, const Function1D& scattering_radius) const
 {
   using namespace std::complex_literals;
 
-  xs.elastic = 0.;
-  xs.capture = 0.;
-  xs.fission = 0.;
-  xs.competitive = 0.;
+  URRXS xs;
 
   double k = wave_number(awr, E);
   double rho = k * channel_radius(E);
@@ -380,6 +377,7 @@ void ResonanceLadder::evaluate(double E, double sqrtkT, double target_spin, doub
     }
   }
   xs.total = xs.elastic + xs.capture + xs.fission;
+  return xs;
 }
 
 //==============================================================================

--- a/src/urr.cpp
+++ b/src/urr.cpp
@@ -96,11 +96,11 @@ Unresolved::Unresolved(hid_t group)
   }
 }
 
-void Unresolved::sample_full_ladder(ResonanceLadder* ladder, uint64_t* seed)
-  const
+ResonanceLadder Unresolved::sample_full_ladder(uint64_t* seed) const
 {
-  ladder->res_.clear();
-  ladder->l_values_.clear();
+  ResonanceLadder ladder;
+  ladder.res_.clear();
+  ladder.l_values_.clear();
 
   int i_res = 0;
 
@@ -148,8 +148,8 @@ void Unresolved::sample_full_ladder(ResonanceLadder* ladder, uint64_t* seed)
         }
 
         // Create resonance
-        ladder->res_.emplace_back();
-        auto& res {ladder->res_.back()};
+        ladder.res_.emplace_back();
+        auto& res {ladder.res_.back()};
         res.E = E;
         res.l = spin_seq.l;
         res.j = spin_seq.j;
@@ -185,7 +185,7 @@ void Unresolved::sample_full_ladder(ResonanceLadder* ladder, uint64_t* seed)
         E += d;
 
         // Add the index of this resonance to the map of l-values
-        ladder->l_values_[res.l].push_back(i_res);
+        ladder.l_values_[res.l].push_back(i_res);
         i_res++;
 
         // If the parameters are energy-dependent (Case C) or fission widths
@@ -195,16 +195,18 @@ void Unresolved::sample_full_ladder(ResonanceLadder* ladder, uint64_t* seed)
       }
     }
   }
+
+  return ladder;
 }
 
-void Unresolved::sample_ladder(double energy, ResonanceLadder* ladder,
-  uint64_t* seed) const
+ResonanceLadder Unresolved::sample_ladder(double energy, uint64_t* seed) const
 {
   // Number of resonances to sample
   int n_res = 100;
 
-  ladder->res_.clear();
-  ladder->l_values_.clear();
+  ResonanceLadder ladder;
+  ladder.res_.clear();
+  ladder.l_values_.clear();
 
   // Find the energy bin
   int i_grid;
@@ -291,7 +293,7 @@ void Unresolved::sample_ladder(double energy, ResonanceLadder* ladder,
 
       // Update resonance parameters and energy
       res.E = E;
-      ladder->res_.push_back(res);
+      ladder.res_.push_back(res);
       if (i < i_mid) {
         E += d;
       } else {
@@ -299,10 +301,12 @@ void Unresolved::sample_ladder(double energy, ResonanceLadder* ladder,
       }
 
       // Add the index of this resonance to the map of l-values
-      ladder->l_values_[res.l].push_back(i_res);
+      ladder.l_values_[res.l].push_back(i_res);
       i_res++;
     }
   }
+
+  return ladder;
 }
 
 //==============================================================================


### PR DESCRIPTION
Two changes here:
1. I've changed `IncidentNeutron.from_njoy` to save unresolved resonance data from the ENDF file. This avoids the need for having a separate urr.h5 file. I've gone through the trouble of generating a new ENDF/B-VII.1 library that includes the unresolved data and can share that with you if you'd like.
2. I've changed `Unresolved::sample_ladder` and `ResonanceLadder::evaluate` so that they directly return `ResonanceLadder` and `URRXS` objects, respectively. Return value optimization will result in essentially the same code as what currently exists.