### PR TITLE
Improvements and bug fixes

### DIFF
--- a/include/openmc/urr.h
+++ b/include/openmc/urr.h
@@ -54,7 +54,7 @@ public:
   struct Resonance {
     double E; //!< Energy
     int l; //!< Neutron orbital angular momentum
-    int j; //!< Total angular momentum
+    double j; //!< Total angular momentum
     double gt; //!< Total width
     double gn; //!< Energy-dependent neutron width
     double gg; //!< Radiation width
@@ -98,7 +98,7 @@ public:
 
   struct SpinSequence {
     int l; //!< Neutron orbital angular momentum
-    int j; //!< Total angular momentum
+    double j; //!< Total angular momentum
     std::vector<URParameters> params; //!< Unresolved resonance parameters
   };
 
@@ -132,7 +132,7 @@ private:
   //! \param[in,out] seed  PRNG seed
   //! \return Sampled resonance
   ResonanceLadder::Resonance sample_resonance(double E, double E_neutron,
-    int l, int j, const URParameters& p, uint64_t* seed) const;
+    int l, double j, const URParameters& p, uint64_t* seed) const;
 
   //! Linearly interpolate average resonance parameters
   //

--- a/include/openmc/urr.h
+++ b/include/openmc/urr.h
@@ -122,6 +122,24 @@ public:
   std::vector<SpinSequence> ljs_; //!< Unresolved resonance parameters at each (l,j)
 
 private:
+  //! Sample a resonance to add to a ladder
+  //
+  //! \param[in] E  Energy of the resonance
+  //! \param[in] E_neutron  Energy at which penetration/shift are calculated at
+  //! \param[in] l  Neutron orbital angular momentum
+  //! \param[in] j  Total angular momentum
+  //! \param[in] p  Average unresolved resonance parameters
+  //! \param[in,out] seed  PRNG seed
+  //! \return Sampled resonance
+  ResonanceLadder::Resonance sample_resonance(double E, double E_neutron,
+    int l, int j, const URParameters& p, uint64_t* seed) const;
+
+  //! Linearly interpolate average resonance parameters
+  //
+  //! \param[in] left  Parameters to the left of energy E
+  //! \param[in] right  Parameters to the right of energy E
+  //! \param[in] E  Energy to interpolate to
+  //! \return Linearly interpolated parameters
   URParameters interpolate_parameters(const URParameters& left,
     const URParameters& right, double E) const;
 };
@@ -154,7 +172,7 @@ std::pair<double, double> penetration_shift(int l, double rho);
 //! Sample from a chi-square distribution
 //!
 //! \param[in] df Number of degrees of freedom
-//! \param[in] seed PRNG seed
+//! \param[in,out] seed PRNG seed
 //! \return Sample drawn from a chi-square distribution
 double chi_square(int df, uint64_t* seed);
 
@@ -162,14 +180,14 @@ double chi_square(int df, uint64_t* seed);
 //
 //! \param[in] avg_width Average resonance width
 //! \param[in] df Number of degrees of freedom
-//! \param[in] seed PRNG seed
+//! \param[in,out] seed PRNG seed
 //! \return Sampled resonance width
 double sample_width(double avg_width, double df, uint64_t* seed);
 
 //! Sample resonance spacing from Wigner distribution
 //
 //! \param[in] avg_spacing Average resonance spacing
-//! \param[in] seed PRNG seed
+//! \param[in,out] seed PRNG seed
 //! \return Sampled resonance spacing
 double sample_spacing(double avg_spacing, uint64_t* seed);
 

--- a/include/openmc/urr.h
+++ b/include/openmc/urr.h
@@ -120,6 +120,10 @@ public:
   std::unique_ptr<Function1D> scattering_radius_;
   std::vector<double> energy_; //!< Energy at which parameters are tabulated
   std::vector<SpinSequence> ljs_; //!< Unresolved resonance parameters at each (l,j)
+
+private:
+  URParameters interpolate_parameters(const URParameters& left,
+    const URParameters& right, double E) const;
 };
 
 //==============================================================================
@@ -153,6 +157,21 @@ std::pair<double, double> penetration_shift(int l, double rho);
 //! \param[in] seed PRNG seed
 //! \return Sample drawn from a chi-square distribution
 double chi_square(int df, uint64_t* seed);
+
+//! Sample resonance width from chi-squared distribution
+//
+//! \param[in] avg_width Average resonance width
+//! \param[in] df Number of degrees of freedom
+//! \param[in] seed PRNG seed
+//! \return Sampled resonance width
+double sample_width(double avg_width, double df, uint64_t* seed);
+
+//! Sample resonance spacing from Wigner distribution
+//
+//! \param[in] avg_spacing Average resonance spacing
+//! \param[in] seed PRNG seed
+//! \return Sampled resonance spacing
+double sample_spacing(double avg_spacing, uint64_t* seed);
 
 } // namespace openmc
 

--- a/src/urr.cpp
+++ b/src/urr.cpp
@@ -99,8 +99,6 @@ Unresolved::Unresolved(hid_t group)
 ResonanceLadder Unresolved::sample_full_ladder(uint64_t* seed) const
 {
   ResonanceLadder ladder;
-  ladder.res_.clear();
-  ladder.l_values_.clear();
 
   int i_res = 0;
 
@@ -168,8 +166,6 @@ ResonanceLadder Unresolved::sample_ladder(double energy, uint64_t* seed) const
   int n_res = 100;
 
   ResonanceLadder ladder;
-  ladder.res_.clear();
-  ladder.l_values_.clear();
 
   // Find the energy bin
   int i_grid;

--- a/src/urr.cpp
+++ b/src/urr.cpp
@@ -72,7 +72,7 @@ Unresolved::Unresolved(hid_t group)
   auto n_rows = matrix.shape()[0];
   for (int i = 0; i < n_rows; ++i) {
     int l = matrix(i, 0);
-    int j = matrix(i, 1);
+    double j = matrix(i, 1);
 
     // New spin sequence (l, j)
     if (ljs_.empty() || j != ljs_.back().j || l != ljs_.back().l) {
@@ -234,7 +234,7 @@ ResonanceLadder Unresolved::sample_ladder(double energy, uint64_t* seed) const
 }
 
 ResonanceLadder::Resonance Unresolved::sample_resonance(double E, double E_neutron,
-  int l, int j, const URParameters& p, uint64_t* seed) const
+  int l, double j, const URParameters& p, uint64_t* seed) const
 {
   // Sample fission width
   double gf = sample_width(p.avg_gf, p.df_f, seed);

--- a/src/urr.cpp
+++ b/src/urr.cpp
@@ -253,7 +253,7 @@ ResonanceLadder::Resonance Unresolved::sample_resonance(double E, double E_neutr
   // Calculate total width
   double gt = gn + p.avg_gg + gf + gx;
 
-  return {E, l, j, gt, gn, 0.0, gf, gx, penetration, shift};
+  return {E, l, j, gt, gn, p.avg_gg, gf, gx, penetration, shift};
 }
 
 Unresolved::URParameters Unresolved::interpolate_parameters(const URParameters& left,


### PR DESCRIPTION
- I've introduced a few methods to better abstract things. Sampling a resonance width / spacing has been separated out into individual methods. I've also added a method for interpolating between two sets of neighboring parameters and a method for sampling a resonance (used in both the full/local ladder methods). The high-level logic becomes a little bit clearer with these changes.
- Bug fix: each instance of `ResonanceLadder::Resonance` wasn't getting a value for the capture width assigned.
- Bug fix: the total angular momentum `j` needs to be a double because it can have half-integral values (U238 does actually)