### PR TITLE
Implement move constructor for ResonanceLadder

### DIFF
--- a/include/openmc/urr.h
+++ b/include/openmc/urr.h
@@ -64,10 +64,14 @@ public:
     double s; //!< Shift factor
   };
 
+  // Constructors
+  ResonanceLadder(std::vector<Resonance>&& res);
+
   // Methods
   URRXS evaluate(double E, double sqrtkT, double target_spin, double awr,
     const Function1D& channel_radius, const Function1D& scattering_radius) const;
 
+private:
   // Data members
   std::vector<Resonance> res_; //!< Sampled resonance parameters
   std::unordered_map<int, std::vector<int>> l_values_;


### PR DESCRIPTION
One more small improvement. In this change, the sample ladder methods now first create a vector of `Resonance` objects which then get passed to a constructor for `ResonanceLadder`. The constructor handles creating the mapping of l values to indices in the vector of resonances (and thus the ladder methods don't need to keep track of that). Making the constructor a move constructor (`&&`) allows the preexisting memory allocated for the `Resonance` objects to be reused rather than being copied to a new block of memory.